### PR TITLE
Fix failure comparing ifstream object with NULL object

### DIFF
--- a/gidserver.cpp
+++ b/gidserver.cpp
@@ -98,7 +98,7 @@ void handle_sighup(int signum) {
     ifstream conf("$HOME/gid/gidserver.conf");
     std::string filepath;
 
-    if(conf == NULL)
+    if(!conf)
         return;
 
     getline(conf, filepath);
@@ -232,7 +232,7 @@ int main() {
 
         /* very bad way to get this done */
         std::ifstream input(GID_PIPE_FILE);
-        if (input == NULL) {
+        if (!input) {
           cout << "[ERROR] Can't open GID_PIPE_FILE: " << GID_PIPE_FILE << endl;
           exit(-2);
         }


### PR DESCRIPTION
ifstream object cannot be compare with a NULL object and following error is produced on compilation: 

```
error: no match for ‘operator==’ (operand types are ‘std::ifstream {aka std::basic_ifstream<char>}’ and ‘long int’)
         if (input == NULL) {
                   ^
```

The patch fixes incompatible comparison